### PR TITLE
Add config option to ignore interfaces, letting the plugin still work…

### DIFF
--- a/src/main/java/com/keyremappingplus/KeyRemappingPlusConfig.java
+++ b/src/main/java/com/keyremappingplus/KeyRemappingPlusConfig.java
@@ -288,6 +288,19 @@ public interface KeyRemappingPlusConfig extends Config
 
 	@ConfigItem(
 		position = 20,
+		keyName = "ignoreInterfaces",
+		name = "Ignore Interfaces",
+		description = "Configures whether this plugin will continue to remap your Fkeys when an interface it open." +
+			"Note that this may have unintended effects, especially if remapping to numerical keys.",
+		section = fKeySection
+	)
+	default boolean interfaceIgnore()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 21,
 		keyName = "space",
 		name = "Space",
 		description = "The key which will replace {Space} when dialogs are open."
@@ -298,7 +311,7 @@ public interface KeyRemappingPlusConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 21,
+		position = 22,
 		keyName = "control",
 		name = "Control",
 		description = "The key which will replace {Control}."
@@ -312,7 +325,7 @@ public interface KeyRemappingPlusConfig extends Config
 		keyName = "promptText",
 		name = "Prompt Text",
 		description = "Changes the text shown which prompts the user to start chatting.",
-		position = 22,
+		position = 23,
 		section = chatPromptSection
 	)
 	default String promptText()
@@ -324,7 +337,7 @@ public interface KeyRemappingPlusConfig extends Config
 		keyName = "promptColor",
 		name = "Prompt Color",
 		description = "Changes the color of the chat prompt text.",
-		position = 23,
+		position = 24,
 		section = chatPromptSection
 	)
 	default Color promptColor()

--- a/src/main/java/com/keyremappingplus/KeyRemappingPlusListener.java
+++ b/src/main/java/com/keyremappingplus/KeyRemappingPlusListener.java
@@ -100,7 +100,7 @@ public class KeyRemappingPlusListener implements KeyListener
 			// In addition to the above checks, the F-key remapping shouldn't
 			// activate when dialogs are open which listen for number keys
 			// to select options
-			if (config.fkeyRemap() && (!config.interfaceIgnore() ? !plugin.isDialogOpen() : true))
+			if (config.fkeyRemap() && !plugin.isDialogOpen(config.interfaceIgnore()))
 			{
 				if (config.f1().matches(e))
 				{
@@ -158,7 +158,7 @@ public class KeyRemappingPlusListener implements KeyListener
 
 			// Do not remap to space key when the options dialog is open, since the options dialog never
 			// listens for space, and the remapped key may be one of keys it listens for.
-			if (plugin.isDialogOpen() && !plugin.isOptionsDialogOpen() && config.space().matches(e))
+			if (plugin.isDialogOpen(false) && !plugin.isOptionsDialogOpen() && config.space().matches(e))
 			{
 				mappedKeyCode = KeyEvent.VK_SPACE;
 			}

--- a/src/main/java/com/keyremappingplus/KeyRemappingPlusListener.java
+++ b/src/main/java/com/keyremappingplus/KeyRemappingPlusListener.java
@@ -100,7 +100,7 @@ public class KeyRemappingPlusListener implements KeyListener
 			// In addition to the above checks, the F-key remapping shouldn't
 			// activate when dialogs are open which listen for number keys
 			// to select options
-			if (config.fkeyRemap() && !plugin.isDialogOpen())
+			if (config.fkeyRemap() && (!config.interfaceIgnore() ? !plugin.isDialogOpen() : true))
 			{
 				if (config.f1().matches(e))
 				{

--- a/src/main/java/com/keyremappingplus/KeyRemappingPlusPlugin.java
+++ b/src/main/java/com/keyremappingplus/KeyRemappingPlusPlugin.java
@@ -145,11 +145,6 @@ public class KeyRemappingPlusPlugin extends Plugin
 			return true;
 		}
 
-		//Place after bank pin so that will still work
-		if (config.interfaceIgnore()) {
-			return false;
-		}
-
 		return isHidden(ComponentID.CHATBOX_MESSAGES) || isHidden(ComponentID.CHATBOX_TRANSPARENT_BACKGROUND_LINES);
 
 	}

--- a/src/main/java/com/keyremappingplus/KeyRemappingPlusPlugin.java
+++ b/src/main/java/com/keyremappingplus/KeyRemappingPlusPlugin.java
@@ -133,7 +133,7 @@ public class KeyRemappingPlusPlugin extends Plugin
 	 *
 	 * @return
 	 */
-	boolean isDialogOpen()
+	boolean isDialogOpen(boolean ignoreInterfaces)
 	{
 		// Most chat dialogs with numerical input are added without the chatbox or its key listener being removed,
 		// so chatboxFocused() is true. The chatbox onkey script uses the following logic to ignore key presses,
@@ -143,6 +143,11 @@ public class KeyRemappingPlusPlugin extends Plugin
 		// Keyboard Bankpin feature of the Bank plugin
 		if (!isHidden(ComponentID.BANK_PIN_CONTAINER)) {
 			return true;
+		}
+
+		//Place after bank pin to ensure that will still work
+		if (ignoreInterfaces) {
+			return false;
 		}
 
 		return isHidden(ComponentID.CHATBOX_MESSAGES) || isHidden(ComponentID.CHATBOX_TRANSPARENT_BACKGROUND_LINES);

--- a/src/main/java/com/keyremappingplus/KeyRemappingPlusPlugin.java
+++ b/src/main/java/com/keyremappingplus/KeyRemappingPlusPlugin.java
@@ -138,10 +138,20 @@ public class KeyRemappingPlusPlugin extends Plugin
 		// Most chat dialogs with numerical input are added without the chatbox or its key listener being removed,
 		// so chatboxFocused() is true. The chatbox onkey script uses the following logic to ignore key presses,
 		// so we will use it too to not remap F-keys.
-		return isHidden(ComponentID.CHATBOX_MESSAGES) || isHidden(ComponentID.CHATBOX_TRANSPARENT_BACKGROUND_LINES)
-			// We want to block F-key remapping in the bank pin interface too, so it does not interfere with the
-			// Keyboard Bankpin feature of the Bank plugin
-			|| !isHidden(ComponentID.BANK_PIN_CONTAINER);
+
+		// We want to block F-key remapping in the bank pin interface too, so it does not interfere with the
+		// Keyboard Bankpin feature of the Bank plugin
+		if (!isHidden(ComponentID.BANK_PIN_CONTAINER)) {
+			return true;
+		}
+
+		//Place after bank pin so that will still work
+		if (config.interfaceIgnore()) {
+			return false;
+		}
+
+		return isHidden(ComponentID.CHATBOX_MESSAGES) || isHidden(ComponentID.CHATBOX_TRANSPARENT_BACKGROUND_LINES);
+
 	}
 
 	boolean isOptionsDialogOpen()


### PR DESCRIPTION
… while in dialogues

Something that has always annoyed me about the base key remapping plugin is that I have to manually hit the inventory, prayer etc buttons while in a dialogue, which comes up a lot while farming, turael skipping etc. This change adds a config option to allow you to do that.