### PR TITLE
Remove Prompt Key Remapping and Add Build details

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -3,3 +3,4 @@ author=Macica2
 description=A clone of the Key Remapping RuneLite plugin with extra features
 tags=enter,chat,wasd,camera
 plugins=com.keyremappingplus.KeyRemappingPlusPlugin
+build=standard

--- a/src/main/java/com/keyremappingplus/KeyRemappingPlusConfig.java
+++ b/src/main/java/com/keyremappingplus/KeyRemappingPlusConfig.java
@@ -333,22 +333,10 @@ public interface KeyRemappingPlusConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "promptKey",
-		name = "Prompt Key",
-		description = "The key which allows the user to start chatting.",
-		position = 24,
-		section = chatPromptSection
-	)
-	default ModifierlessKeybind promptKey()
-	{
-		return new ModifierlessKeybind(KeyEvent.VK_ENTER, 0);
-	}
-
-	@ConfigItem(
 		keyName = "promptText",
 		name = "Prompt Text",
 		description = "Changes the text shown which prompts the user to start chatting.",
-		position = 25,
+		position = 24,
 		section = chatPromptSection
 	)
 	default String promptText()
@@ -360,7 +348,7 @@ public interface KeyRemappingPlusConfig extends Config
 		keyName = "promptColor",
 		name = "Prompt Color",
 		description = "Changes the color of the chat prompt text.",
-		position = 26,
+		position = 25,
 		section = chatPromptSection
 	)
 	default Color promptColor()

--- a/src/main/java/com/keyremappingplus/KeyRemappingPlusListener.java
+++ b/src/main/java/com/keyremappingplus/KeyRemappingPlusListener.java
@@ -168,11 +168,6 @@ public class KeyRemappingPlusListener implements KeyListener
 				mappedKeyCode = KeyEvent.VK_CONTROL;
 			}
 
-			if (config.promptKey().matches(e))
-			{
-				mappedKeyCode = KeyEvent.VK_ENTER;
-			}
-
 			if (config.shift().matches(e))
 			{
 				mappedKeyCode = KeyEvent.VK_SHIFT;


### PR DESCRIPTION
Removed Prompt Key remapping functionality temporarily as this was written by another author who did not keep the plugin hub up to date with the change.

Added missing "build=standard" line from runelite-plugin.properties which is necessary to pass plugin hub CI/CD pipeline.